### PR TITLE
Add memory usage percentage to menu details

### DIFF
--- a/Sources/VitalBarApp/UI/MenuBarContentView.swift
+++ b/Sources/VitalBarApp/UI/MenuBarContentView.swift
@@ -39,9 +39,14 @@ struct MenuBarContentView: View {
             HStack {
                 Text("Memory Used")
                 Spacer()
-                Text(viewModel.memoryUsageText)
-                    .fontWeight(.semibold)
-                    .monospacedDigit()
+
+                HStack(spacing: 8) {
+                    Text(viewModel.memoryUsageText)
+                    Text("(\(viewModel.memoryUsagePercentText))")
+                        .foregroundStyle(.secondary)
+                }
+                .fontWeight(.semibold)
+                .monospacedDigit()
             }
 
             HStack {

--- a/Sources/VitalBarApp/UI/MenuBarViewModel.swift
+++ b/Sources/VitalBarApp/UI/MenuBarViewModel.swift
@@ -7,6 +7,7 @@ final class MenuBarViewModel: ObservableObject {
     @Published private(set) var samples: [CPULoadSample] = []
     @Published private(set) var currentUsageText = "--%"
     @Published private(set) var memoryUsageText = "-- / --"
+    @Published private(set) var memoryUsagePercentText = "--%"
     @Published private(set) var memoryPressureText = "--"
     @Published private(set) var memoryPressureLevel: MemoryPressureLevel?
     @Published private(set) var appMemoryText = "--"
@@ -100,6 +101,15 @@ final class MenuBarViewModel: ObservableObject {
         }
     }
 
+    static func memoryUsagePercentText(for sample: MemoryUsageSample?) -> String {
+        guard let sample, sample.totalBytes > 0 else {
+            return "--%"
+        }
+
+        let usage = Double(sample.usedBytes) / Double(sample.totalBytes)
+        return percentText(for: usage)
+    }
+
     static func bytesText(for bytes: UInt64?) -> String {
         guard let bytes else {
             return "--"
@@ -129,6 +139,7 @@ final class MenuBarViewModel: ObservableObject {
         samples = snapshot.history
         currentUsageText = Self.percentText(for: snapshot.latest?.usage)
         memoryUsageText = Self.memoryFractionText(for: snapshot.memoryUsage)
+        memoryUsagePercentText = Self.memoryUsagePercentText(for: snapshot.memoryUsage)
         memoryPressureLevel = snapshot.memoryUsage?.pressureLevel
         memoryPressureText = Self.memoryPressureText(for: snapshot.memoryUsage)
         appMemoryText = Self.bytesText(for: snapshot.memoryUsage?.appBytes)

--- a/Tests/VitalBarAppTests/MenuBarViewModelTests.swift
+++ b/Tests/VitalBarAppTests/MenuBarViewModelTests.swift
@@ -74,6 +74,7 @@ final class MenuBarViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.samples.count, 120)
         XCTAssertEqual(viewModel.currentUsageText, MenuBarViewModel.percentText(for: samples.last?.usage))
         XCTAssertEqual(viewModel.memoryUsageText, "8.0 GB / 16.0 GB")
+        XCTAssertEqual(viewModel.memoryUsagePercentText, "50%")
         XCTAssertEqual(viewModel.memoryPressureText, "Warning")
         XCTAssertEqual(viewModel.appMemoryText, "4.0 GB")
         XCTAssertEqual(viewModel.wiredMemoryText, "2.0 GB")
@@ -118,6 +119,7 @@ final class MenuBarViewModelTests: XCTestCase {
         XCTAssertTrue(viewModel.isStale)
         XCTAssertEqual(viewModel.currentUsageText, "42%")
         XCTAssertEqual(viewModel.memoryUsageText, "12.0 GB / 16.0 GB")
+        XCTAssertEqual(viewModel.memoryUsagePercentText, "75%")
         XCTAssertEqual(viewModel.memoryPressureText, "Normal")
         XCTAssertEqual(viewModel.appMemoryText, "6.0 GB")
         XCTAssertEqual(viewModel.wiredMemoryText, "3.0 GB")
@@ -153,6 +155,25 @@ final class MenuBarViewModelTests: XCTestCase {
                 for: MemoryUsageSample(usedBytes: 8 * gib, totalBytes: 16 * gib)
             ),
             "8.0 GB / 16.0 GB"
+        )
+    }
+
+    @MainActor
+    func testMemoryUsagePercentFormatting() {
+        let gib = UInt64(1_073_741_824)
+
+        XCTAssertEqual(MenuBarViewModel.memoryUsagePercentText(for: nil), "--%")
+        XCTAssertEqual(
+            MenuBarViewModel.memoryUsagePercentText(
+                for: MemoryUsageSample(usedBytes: 3 * gib, totalBytes: 8 * gib)
+            ),
+            "38%"
+        )
+        XCTAssertEqual(
+            MenuBarViewModel.memoryUsagePercentText(
+                for: MemoryUsageSample(usedBytes: 5 * gib, totalBytes: 0)
+            ),
+            "--%"
         )
     }
 


### PR DESCRIPTION
### Motivation
- Make memory usage easier to scan by showing a percentage alongside the existing `used / total` display in the menu details.
- Ensure the formatting is robust for missing samples and zero `totalBytes` values.

### Description
- Added a published property `memoryUsagePercentText` to `MenuBarViewModel` and a helper `memoryUsagePercentText(for:)` that converts `usedBytes / totalBytes` into the existing percent string format via `percentText(for:)` while handling `nil` and zero-total cases returning `--%`.
- Updated `MenuBarViewModel.apply(_:)` to set `memoryUsagePercentText` from incoming `CPUHistorySnapshot` data.
- Updated `MenuBarContentView` to show `memoryUsagePercentText` next to the `memoryUsageText` in the `Memory Used` row using a small secondary-styled label.
- Extended `Tests/VitalBarAppTests/MenuBarViewModelTests.swift` to assert the percentage in streamed snapshots for normal and stale states and added `testMemoryUsagePercentFormatting` to cover formatting edge cases.

### Testing
- Ran `swift test` in the container to verify changes, but the run failed due to the environment being Linux and the package importing macOS-only module `Darwin.Mach` (build error), so tests could not complete here.
- Unit tests were updated to include assertions for the new percentage output and a dedicated formatting test; these are expected to pass on macOS where `swift test` can build the package successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699a97662314832ebadc73ac5e10b54a)