### PR TITLE
Add framed styling to CPU graph in dropdown menu

### DIFF
--- a/Sources/VitalBarApp/UI/MenuBarContentView.swift
+++ b/Sources/VitalBarApp/UI/MenuBarContentView.swift
@@ -27,6 +27,15 @@ struct MenuBarContentView: View {
 
             SparklineView(samples: viewModel.samples, color: cpuColor)
                 .frame(height: 48)
+                .padding(6)
+                .background {
+                    RoundedRectangle(cornerRadius: 6)
+                        .fill(Color(nsColor: .controlBackgroundColor))
+                }
+                .overlay {
+                    RoundedRectangle(cornerRadius: 6)
+                        .strokeBorder(Color.secondary.opacity(0.35), lineWidth: 1)
+                }
 
             HStack {
                 Text("Current CPU")


### PR DESCRIPTION
### Motivation
- Visually separate the CPU usage sparkline inside the dropdown menu by adding a frame so the graph is more readable and matches the requested UI change.

### Description
- Update `Sources/VitalBarApp/UI/MenuBarContentView.swift` to wrap the `SparklineView` with `.padding(6)`, a rounded background using `RoundedRectangle(cornerRadius: 6).fill(Color(nsColor: .controlBackgroundColor))`, and a subtle rounded border using `.overlay { RoundedRectangle(cornerRadius: 6).strokeBorder(Color.secondary.opacity(0.35), lineWidth: 1) }`.

### Testing
- Ran `swift test`, which failed in this environment due to the installed Swift tools being `6.1.3` while the package requires `6.2.0`, so unit tests could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699b1f679fa4832ebc469b60688d4cf3)