### PR TITLE
Match uptime row emphasis with disk usage section

### DIFF
--- a/Sources/VitalBarApp/UI/MenuBarContentView.swift
+++ b/Sources/VitalBarApp/UI/MenuBarContentView.swift
@@ -118,9 +118,9 @@ struct MenuBarContentView: View {
 
             HStack {
                 Text("Uptime")
-                    .foregroundStyle(.secondary)
                 Spacer()
                 Text(viewModel.uptimeText)
+                    .fontWeight(.semibold)
                     .monospacedDigit()
             }
 


### PR DESCRIPTION
### Motivation
- The uptime entry should visually start a new section and share the same emphasis as the Disk Usage row so the menu layout reads clearly.

### Description
- Update `Sources/VitalBarApp/UI/MenuBarContentView.swift` to remove `.foregroundStyle(.secondary)` from the "Uptime" label and apply `.fontWeight(.semibold)` to the uptime value so it matches the Disk Usage styling.

### Testing
- Ran `swift test` in this environment and it failed due to a toolchain mismatch (package requires Swift 6.2.0 but the environment has Swift 6.1.3).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699bb04a6d0c832e87ee0690409e6d49)